### PR TITLE
Add hamburger menu for mobile header navigation

### DIFF
--- a/aboutme.html
+++ b/aboutme.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
+    <script src="index.js" defer></script>
     <title>about</title>
 </head>
 
@@ -12,13 +13,15 @@
     <section>
     <header>
         <h2>GadgetFreak</h2>
-        <nav>
-            <ul>
+        <button class="nav-toggle" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="primary-menu">
+            ☰
+        </button>
+        <nav class="site-nav">
+            <ul id="primary-menu">
                 <li><a href="/index.html">Home</a></li>
                 <li><a href="/aboutme.html">About</a></li>
                 <li><a href="/project.html">Progect</a></li>
-                <li><a href="https://www.twitter.com/messages/compose?recipient_id=[@M9zRs0VDM9RTU7B]">Contact</a>
-                </li>
+                <li><a href="https://www.twitter.com/messages/compose?recipient_id=[@M9zRs0VDM9RTU7B]">Contact</a></li>
             </ul>
         </nav>
     </header>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="GadgetFreakのサイト" />
     <link rel="stylesheet" href="style.css">
-    <script src="index.js"></script>
+    <script src="index.js" defer></script>
     <title>GadgetFreak's website</title>
 </head>
 
@@ -14,13 +14,15 @@
     <!-- header section-->
     <header>
         <h2>GadgetFreak</h2>
-        <nav>
-            <ul>
+        <button class="nav-toggle" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="primary-menu">
+            ☰
+        </button>
+        <nav class="site-nav">
+            <ul id="primary-menu">
                 <li><a href="#">Home</a></li>
                 <li><a href="">Link</a></li>
                 <li><a href="">Developed</a></li>
                 <li><a href="">About me</a></li>
-                </li>
             </ul>
         </nav>
     </header>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const mobileWidth = 768;
+
+    document.querySelectorAll("header").forEach((header) => {
+        const toggleButton = header.querySelector(".nav-toggle");
+        const siteNav = header.querySelector(".site-nav");
+
+        if (!toggleButton || !siteNav) {
+            return;
+        }
+
+        const closeMenuIfDesktop = () => {
+            if (window.innerWidth > mobileWidth) {
+                siteNav.classList.remove("is-open");
+                toggleButton.setAttribute("aria-expanded", "false");
+            }
+        };
+
+        toggleButton.addEventListener("click", () => {
+            const isOpen = siteNav.classList.toggle("is-open");
+            toggleButton.setAttribute("aria-expanded", String(isOpen));
+        });
+
+        window.addEventListener("resize", closeMenuIfDesktop);
+    });
+});

--- a/project.html
+++ b/project.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
+    <script src="index.js" defer></script>
     <title>project</title>
 </head>
 
@@ -12,13 +13,15 @@
     <section>
         <header>
             <h2>GadgetFreak</h2>
-            <nav>
-                <ul>
-                    <li><a href="#">Home</a></li>
+            <button class="nav-toggle" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="primary-menu">
+                ☰
+            </button>
+            <nav class="site-nav">
+                <ul id="primary-menu">
+                    <li><a href="/index.html">Home</a></li>
                     <li><a href="/aboutme.html">About</a></li>
-                    <li><a href="/project.html"></a>Project</li>
-                    <li><a href="https://www.twitter.com/messages/compose?recipient_id=[@M9zRs0VDM9RTU7B]">Contact</a>
-                    </li>
+                    <li><a href="/project.html">Project</a></li>
+                    <li><a href="https://www.twitter.com/messages/compose?recipient_id=[@M9zRs0VDM9RTU7B]">Contact</a></li>
                 </ul>
             </nav>
         </header>

--- a/style.css
+++ b/style.css
@@ -61,6 +61,16 @@ header h2 {
     font-size: 25px;
 }
 
+.nav-toggle {
+    display: none;
+    font-size: 28px;
+    line-height: 1;
+    border: none;
+    background: transparent;
+    color: white;
+    cursor: pointer;
+}
+
 .title_main {
     padding-top: 20px;
     padding-bottom: 20px;
@@ -217,8 +227,8 @@ footer {
 
 @media (max-width: 768px) {
     header {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-wrap: wrap;
+        align-items: center;
         gap: 10px;
         padding: 12px 16px 16px;
     }
@@ -227,30 +237,42 @@ footer {
         font-size: 22px;
     }
 
-    header nav {
+    .nav-toggle {
+        display: block;
+        margin-left: auto;
+    }
+
+    .site-nav {
         width: 100%;
+        display: none;
     }
 
-    header nav ul {
-        gap: 12px;
+    .site-nav.is-open {
+        display: block;
     }
 
-    .name_title {
-        font-size: 24px;
-    }
-   
-    .hero-card_inner {
-        flex-direction: column;
-    }
-}
-
-@media (max-width: 480px) {
     header nav ul {
         flex-direction: column;
         align-items: flex-start;
         gap: 8px;
     }
 
+    .name_title {
+        font-size: 24px;
+    }
+
+    .hero-card_inner {
+        flex-direction: column;
+    }
+}
+
+@media (min-width: 769px) {
+    .site-nav {
+        display: block !important;
+    }
+}
+
+@media (max-width: 480px) {
     #imgs {
         width: min(180px, 58vw);
     }


### PR DESCRIPTION
### Motivation
- Make the header navigation usable on mobile by collapsing the header links into a hamburger menu on small screens (<= 768px). 
- Improve accessibility by adding a toggle button with `aria-expanded` and ensure the navigation works reliably when resizing between mobile and desktop. 
- Fix minor malformed header/list markup found in several pages while updating the structure.

### Description
- Added a hamburger toggle button (`.nav-toggle`) and wrapped existing header links in a `.site-nav` container with `ul#primary-menu` in `index.html`, `aboutme.html` and `project.html`, and changed the script tag to load `index.js` with `defer`.
- Implemented responsive CSS in `style.css` including `.nav-toggle` styles, `.site-nav` show/hide behavior, and media-query rules so the menu is hidden by default on mobile and always visible on desktop (`min-width: 769px`).
- Added `index.js` to handle toggle clicks, synchronize `aria-expanded`, and automatically close the mobile menu when the viewport is resized above the mobile breakpoint.
- Cleaned up malformed list markup in `index.html` and `project.html` and added the same header structure to `aboutme.html` for consistency across pages.

### Testing
- Ran `node --check index.js` which succeeded. 
- Launched a local static server (`python3 -m http.server 8000`) to exercise pages which started successfully. 
- Attempted end-to-end visual verification with Playwright, but Chromium crashed in this environment and Firefox timed out so automated screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e5f980c08328bcf64ae3e2dd61e1)